### PR TITLE
Fixing regression: upload promise can be rejected

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,8 @@
   },
   "devDependencies": {
     "qunit": "~1.13.0",
-    "loader.js": "~1.0.1"
+    "loader.js": "~1.0.1",
+    "sinon": "~1.12.2"
   },
   "ignore": [
     "**/.*",

--- a/dist/ember-uploader.js
+++ b/dist/ember-uploader.js
@@ -247,6 +247,7 @@ define("ember-uploader/uploader",
           return respData;
         }, function(jqXHR, textStatus, errorThrown) {
           self.didError(jqXHR, textStatus, errorThrown);
+          throw errorThrown;
         });
       },
 
@@ -292,7 +293,7 @@ define("ember-uploader/uploader",
       didError: function(jqXHR, textStatus, errorThrown) {
         set(this, 'isUploading', false);
         this.trigger('didError', jqXHR, textStatus, errorThrown);
-      }, 
+      },
 
       didProgress: function(e) {
         e.percent = e.loaded / e.total * 100;

--- a/dist/ember-uploader.named-amd.js
+++ b/dist/ember-uploader.named-amd.js
@@ -135,6 +135,7 @@ define("ember-uploader/uploader",
           return respData;
         }, function(jqXHR, textStatus, errorThrown) {
           self.didError(jqXHR, textStatus, errorThrown);
+          throw errorThrown;
         });
       },
 
@@ -180,7 +181,7 @@ define("ember-uploader/uploader",
       didError: function(jqXHR, textStatus, errorThrown) {
         set(this, 'isUploading', false);
         this.trigger('didError', jqXHR, textStatus, errorThrown);
-      }, 
+      },
 
       didProgress: function(e) {
         e.percent = e.loaded / e.total * 100;

--- a/packages/ember-uploader/lib/uploader.js
+++ b/packages/ember-uploader/lib/uploader.js
@@ -35,6 +35,7 @@ export default Ember.Object.extend(Ember.Evented, {
       return respData;
     }, function(jqXHR, textStatus, errorThrown) {
       self.didError(jqXHR, textStatus, errorThrown);
+      throw errorThrown;
     });
   },
 
@@ -80,7 +81,7 @@ export default Ember.Object.extend(Ember.Evented, {
   didError: function(jqXHR, textStatus, errorThrown) {
     set(this, 'isUploading', false);
     this.trigger('didError', jqXHR, textStatus, errorThrown);
-  }, 
+  },
 
   didProgress: function(e) {
     e.percent = e.loaded / e.total * 100;

--- a/packages/ember-uploader/tests/unit/uploader_test.js
+++ b/packages/ember-uploader/tests/unit/uploader_test.js
@@ -29,9 +29,14 @@ module("EmberUploader.Uploader", {
     FormData.prototype.append = function(name, value) {
       FormData.data[name] = value;
     };
+
+    window.server = sinon.fakeServer.create();
+    window.server.autoRespond = true;
   },
 
   teardown: function() {
+    window.server.restore();
+
     FormData.reset();
     FormData = OldFormData;
   }
@@ -72,43 +77,80 @@ test("it can upload multiple files", function() {
   equal(FormData.data['files[2]'], 3);
 });
 
-// TODO: Reimplement this test without actually uploading
+test("uploads to the given url", function() {
+  window.server.respondWith('POST', '/upload', [200, {}, 'OK']);
 
-// test("uploads to the given url", function() {
-//   expect(1);
-// 
-//   var uploader = Uploader.create({
-//     url: '/api/upload',
-//     file: file
-//   });
-// 
-//   uploader.on('didUpload', function(data) {
-//     start();
-//     equal(data, 'OK');
-//   });
-// 
-//   uploader.upload(file);
-// 
-//   stop();
-// });
+  expect(1);
+
+  var uploader = Uploader.create({
+    url: '/upload',
+    file: file
+  });
+
+  uploader.on('didUpload', function(data) {
+    start();
+    equal(data, 'OK');
+  });
+
+  uploader.upload(file);
+
+  stop();
+});
+
+test("uploads promise gets resolved", function() {
+  window.server.respondWith('POST', '/upload', [200, {}, 'OK']);
+
+  expect(1);
+
+  var uploader = Uploader.create({
+    url: '/upload',
+    file: file
+  });
+
+  uploader.upload(file).then(function(data) {
+    start();
+    equal(data, 'OK');
+  });
+
+  stop();
+});
+
+test("uploads promise gets rejected", function() {
+  window.server.respondWith('POST', '/upload', [400, {}, '']);
+
+  expect(1);
+
+  var uploader = Uploader.create({
+    url: '/upload',
+    file: file
+  });
+
+  uploader.upload(file).then(function(data) {
+  }, function(data) {
+    start();
+    ok(true);
+  });
+
+  stop();
+});
 
 // TODO: Reimplement this test without actually uploading
 
 // test("emits progress event", function() {
 //   expect(1);
-// 
+//
 //   var uploader = Uploader.create({
 //     url: '/upload',
 //     file: file
 //   });
-// 
+//
 //   uploader.on('progress', function(e) {
 //     start();
 //     equal(e.percent, 100);
 //   });
-// 
+//
 //   uploader.upload(file);
-// 
+//
 //   stop();
 // });
 

--- a/tests/index.html
+++ b/tests/index.html
@@ -6,6 +6,13 @@
   <link rel="stylesheet" href="bower_components/qunit/qunit/qunit.css">
   <script src="bower_components/qunit/qunit/qunit.js"></script>
   <script src="/testem.js"></script>
+  <script src="bower_components/sinon/lib/sinon.js"></script>
+  <script src="bower_components/sinon/lib/sinon/format.js"></script>
+  <script src="bower_components/sinon/lib/sinon/log_error.js"></script>
+  <script src="bower_components/sinon/lib/sinon/extend.js"></script>
+  <script src="bower_components/sinon/lib/sinon/util/event.js"></script>
+  <script src="bower_components/sinon/lib/sinon/util/fake_xml_http_request.js"></script>
+  <script src="bower_components/sinon/lib/sinon/util/fake_server.js"></script>
   <script src="bower_components/handlebars/handlebars.js"></script>
   <script src="bower_components/jquery/dist/jquery.js"></script>
   <script src="bower_components/ember/ember.js"></script>


### PR DESCRIPTION
Using sinon.js to mock server responses.

Details:
In older releases this promise errors where not resolved: https://github.com/benefitcloud/ember-uploader/pull/49 The problem is that failing requestes will be handled on success callback on the users API.