### PR TITLE
Ajax errors propagate to rejected promise in ic_ajax fashion

### DIFF
--- a/dist/ember-uploader.js
+++ b/dist/ember-uploader.js
@@ -245,9 +245,9 @@ define("ember-uploader/uploader",
         return this.ajax(url, data, type).then(function(respData) {
           self.didUpload(respData);
           return respData;
-        }, function(jqXHR, textStatus, errorThrown) {
-          self.didError(jqXHR, textStatus, errorThrown);
-          throw errorThrown;
+        }, function(error) {
+          self.didError(error.jqXHR, error.textStatus, error.errorThrown);
+          throw error;
         });
       },
 
@@ -336,7 +336,11 @@ define("ember-uploader/uploader",
           };
 
           settings.error = function(jqXHR, textStatus, errorThrown) {
-            Ember.run(null, reject, jqXHR);
+            Ember.run(null, reject, {
+              jqXHR: jqXHR,
+              textStatus: textStatus,
+              errorThrown: errorThrown
+            });
           };
 
           Ember.$.ajax(settings);

--- a/dist/ember-uploader.named-amd.js
+++ b/dist/ember-uploader.named-amd.js
@@ -133,9 +133,9 @@ define("ember-uploader/uploader",
         return this.ajax(url, data, type).then(function(respData) {
           self.didUpload(respData);
           return respData;
-        }, function(jqXHR, textStatus, errorThrown) {
-          self.didError(jqXHR, textStatus, errorThrown);
-          throw errorThrown;
+        }, function(error) {
+          self.didError(error.jqXHR, error.textStatus, error.errorThrown);
+          throw error;
         });
       },
 
@@ -224,7 +224,11 @@ define("ember-uploader/uploader",
           };
 
           settings.error = function(jqXHR, textStatus, errorThrown) {
-            Ember.run(null, reject, jqXHR);
+            Ember.run(null, reject, {
+              jqXHR: jqXHR,
+              textStatus: textStatus,
+              errorThrown: errorThrown
+            });
           };
 
           Ember.$.ajax(settings);

--- a/packages/ember-uploader/lib/uploader.js
+++ b/packages/ember-uploader/lib/uploader.js
@@ -33,9 +33,9 @@ export default Ember.Object.extend(Ember.Evented, {
     return this.ajax(url, data, type).then(function(respData) {
       self.didUpload(respData);
       return respData;
-    }, function(jqXHR, textStatus, errorThrown) {
-      self.didError(jqXHR, textStatus, errorThrown);
-      throw errorThrown;
+    }, function(error) {
+      self.didError(error.jqXHR, error.textStatus, error.errorThrown);
+      throw error;
     });
   },
 
@@ -124,7 +124,11 @@ export default Ember.Object.extend(Ember.Evented, {
       };
 
       settings.error = function(jqXHR, textStatus, errorThrown) {
-        Ember.run(null, reject, jqXHR);
+        Ember.run(null, reject, {
+          jqXHR: jqXHR,
+          textStatus: textStatus,
+          errorThrown: errorThrown
+        });
       };
 
       Ember.$.ajax(settings);


### PR DESCRIPTION
Following ic_ajax style the errors should be propagated to reject callback.