### PR TITLE
S3 renaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ saving secret token on your client.
 
 ```js
 App.S3UploadComponent = EmberUploader.FileField.extend({
-  url: ''
+  url: '',
 
   filesDidChange: (function() {
     var uploadUrl = this.get('url');
@@ -177,6 +177,32 @@ App.S3UploadComponent = EmberUploader.FileField.extend({
 ```
 
 For learning how to setup the backend, check the [wiki](https://github.com/benefitcloud/ember-uploader/wiki/S3-Server-Setup)
+
+#### Naming file uploads to S3
+You can easily set the name of a user uploaded file going directly to s3 by defining a fileName function when you create your S3Uploader instance.
+
+```js
+import Ember from 'ember';
+import EmberUploader from 'ember-uploader';
+
+export default EmberUploader.FileField.extend({
+  ...
+  
+  filesDidChange: (function() {
+    ...
+
+    var uploader = EmberUploader.S3Uploader.create({
+      // Add a timestamp to the filename
+      fileName: function(name, ext) {
+        return name + "-" + new Date().getTime() + ext;
+      }
+    });
+    
+    ...
+  }).observes('files')
+});
+
+```
 
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality.

--- a/packages/ember-uploader/lib/s3.js
+++ b/packages/ember-uploader/lib/s3.js
@@ -42,7 +42,7 @@ export default Uploader.extend({
     var self = this;
 
     data = data || {};
-    data.name = file.name;
+    data.name = this.generateFileName(file.name);
     data.type = file.type;
     data.size = file.size;
 
@@ -65,5 +65,21 @@ export default Uploader.extend({
 
       Ember.$.ajax(settings);
     });
+  },
+
+  generateFileName: function(fullName) {
+    // Default return value
+    var ret = fullName;
+
+    // Only customize name if our override function exists
+    if(typeof this.fileName === 'function') {
+      var extension = '.' + fullName.split('.').pop(),
+          name      = fullName.substr(0, fullName.lastIndexOf('.'));
+
+      ret = this.fileName(name, extension);
+    }
+
+    // Return processed name
+    return ret;
   }
 });

--- a/packages/ember-uploader/tests/unit/s3_test.js
+++ b/packages/ember-uploader/tests/unit/s3_test.js
@@ -56,6 +56,27 @@ test("it uploads after signing", function() {
   stop();
 });
 
+test("it can override the name of the file being uploaded", function() {
+  expect(1);
+
+  var uploader = Uploader.create({
+    // Filename Override
+    fileName: function(name, ext) {
+      return name + '-cust-filename' + ext;
+    },
+  });
+
+  equal(uploader.generateFileName('file.mp4'), 'file-cust-filename.mp4');
+});
+
+test("it takes the filename as given if no override exists", function() {
+  expect(1);
+
+  var uploader = Uploader.create();
+
+  equal(uploader.generateFileName('file.mp4'), 'file.mp4');
+});
+
 // TODO: Reimplement this test without actually using S3
 
 // test("uploads to s3", function() {


### PR DESCRIPTION
Added the ability to name files getting uploaded to s3. This is useful if you want to regex out characters (such as the # symbol which breaks s3 urls), timestamp urls, etc. It's done by the user defining a function called "fileName" when creating their S3Uploader object. If no function is defined it defaults to the original filename.