### PR TITLE
Add link to ember-cli-upload in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Download the [production version][min] or the [development version][max].
 
 or using bower `bower install ember-uploader --save`
 
+For Ember CLI applications please use [ember-cli-uploader](https://github.com/benefitcloud/ember-cli-uploader).
+
 #### Basic Setup
 Create new component and extend `EmberUploader.FileField` provided by ember-uploader. If you're using `EmberUploader.FileField`, it will automatically give you an input field, and will set `files` property when you choose a file.
 


### PR DESCRIPTION
This PR documents the existence of the ember-cli-uploader. A couple of the issues (e.g. #63 and #65) make it clear that some users are unaware that an Ember CLI add-on exists for ember-uploader.