### PR TITLE
Make `filesDidChange` an actual hook using Evented.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,8 @@ Create new component and extend `EmberUploader.FileField` provided by ember-uplo
 ```js
 App.FileUploadComponent = EmberUploader.FileField.extend({
   url: '',
-  filesDidChange: (function() {
+  filesDidChange: function(files) {
     var uploadUrl = this.get('url');
-    var files = this.get('files');
 
     var uploader = EmberUploader.Uploader.create({
       url: uploadUrl
@@ -30,7 +29,7 @@ App.FileUploadComponent = EmberUploader.FileField.extend({
     if (!Ember.isEmpty(files)) {
       uploader.upload(files[0]);
     }
-  }).observes('files')
+  }
 });
 ```
 For Ember CLI projects:
@@ -43,9 +42,8 @@ import EmberUploader from 'ember-uploader';
 
 export default EmberUploader.FileField.extend({
   url: '',
-  filesDidChange: (function() {
+  filesDidChange: function(files) {
     var uploadUrl = this.get('url');
-    var files = this.get('files');
 
     var uploader = EmberUploader.Uploader.create({
       url: uploadUrl
@@ -54,7 +52,7 @@ export default EmberUploader.FileField.extend({
     if (!Ember.isEmpty(files)) {
       uploader.upload(files[0]);
     }
-  }).observes('files')
+  }
 });
 ```
 
@@ -138,16 +136,15 @@ App.FileUploadComponent = EmberUploader.FileField.extend({
   multiple: true,
   url: '',
 
-  filesDidChange: (function() {
+  filesDidChange: function(files) {
     var uploadUrl = this.get('url');
-    var files = this.get('files');
 
     var uploader = EmberUploader.Uploader.create({ url: uploadUrl });
 
     if (!Ember.isEmpty(files)) {
       uploader.upload(files);
     }
-  }).observes('files')
+  }
 });
 ```
 
@@ -164,9 +161,8 @@ saving secret token on your client.
 App.S3UploadComponent = EmberUploader.FileField.extend({
   url: '',
 
-  filesDidChange: (function() {
+  filesDidChange: function(files) {
     var uploadUrl = this.get('url');
-    var files = this.get('files');
 
     var uploader = EmberUploader.S3Uploader.create({
       url: uploadUrl
@@ -181,7 +177,7 @@ App.S3UploadComponent = EmberUploader.FileField.extend({
     if (!Ember.isEmpty(files)) {
       uploader.upload(files[0]); // Uploader will send a sign request then upload to S3
     }
-  }).observes('files')
+  }
 });
 
 ```

--- a/packages/ember-uploader/lib/file-field.js
+++ b/packages/ember-uploader/lib/file-field.js
@@ -1,13 +1,22 @@
+var deprecate = Ember.deprecate;
 var set = Ember.set;
+var on = Ember.on;
 
-export default Ember.TextField.extend({
+export default Ember.TextField.extend(Ember.Evented, {
   type: 'file',
   attributeBindings: ['multiple'],
   multiple: false,
   change: function(e) {
     var input = e.target;
     if (!Ember.isEmpty(input.files)) {
-      set(this, 'files', input.files);
+      this.trigger('filesDidChange', input.files);
+      set(this, 'files', input.files); // to be removed in future release, needed for `files` observer to continue working
     }
-  }
+  },
+
+  _deprecateFileObserver: on('init', function() {
+    var hasFilesObserver = this.hasObserverFor('files');
+
+    deprecate('Observing the `files` attr is deprecated, use `filesDidChange` instead.', !hasFilesObserver);
+  })
 });

--- a/packages/ember-uploader/tests/unit/file_field_test.js
+++ b/packages/ember-uploader/tests/unit/file_field_test.js
@@ -1,0 +1,37 @@
+/* global EmberUploader */
+
+var FileField;
+
+module("EmberUploader.FileField");
+
+test("it triggers `filesDidChange` on change", function() {
+  var result;
+  expect(1);
+
+  var FileField = EmberUploader.FileField.extend({
+    filesDidChange: function(files) {
+      result = files;
+    }
+  });
+  var fileField = FileField.create();
+  fileField.change({ target: { files: [ 'foo' ] }});
+
+  deepEqual(result, [ 'foo' ], 'it returns the files that changed');
+});
+
+test("it can observe the files attr", function() {
+  var result;
+  expect(1);
+
+  var FileField = EmberUploader.FileField.extend({
+    filesDidChange: Ember.observer('files', function() {
+      var files = this.get('files');
+
+      result = files;
+    })
+  });
+  var fileField = FileField.create();
+  fileField.change({ target: { files: [ 'foo' ] }});
+
+  deepEqual(result, [ 'foo' ], 'it returns the files that changed');
+});


### PR DESCRIPTION
This allows the use of `filesDidChange` as an actual hook, instead of an
observer. Also adds a deprecation warning that informs that users should
switch to using the hook instead.