### PR TITLE
Pass deprecation options to Ember.deprecate()

### DIFF
--- a/packages/ember-uploader/lib/file-field.js
+++ b/packages/ember-uploader/lib/file-field.js
@@ -17,6 +17,9 @@ export default Ember.TextField.extend(Ember.Evented, {
   _deprecateFileObserver: on('init', function() {
     var hasFilesObserver = this.hasObserverFor('files');
 
-    deprecate('Observing the `files` attr is deprecated, use `filesDidChange` instead.', !hasFilesObserver);
+    deprecate('Observing the `files` attr is deprecated, use `filesDidChange` instead.', !hasFilesObserver, {
+      id: 'ember-uploader.files-attr',
+      until: '1.0'
+    });
   })
 });

--- a/packages/ember-uploader/lib/s3.js
+++ b/packages/ember-uploader/lib/s3.js
@@ -94,7 +94,10 @@ export default Uploader.extend({
 
   _deprecateHeadersProperty: on('init', function() {
     if (this.get('headers')) {
-      deprecate('Using the `headers` property is deprecated, override `ajaxSignSettings` or `ajaxSettings` instead');
+      deprecate('Using the `headers` property is deprecated, override `ajaxSignSettings` or `ajaxSettings` instead', {
+        id: 'ember-uploader.s3.headers',
+        until: '1.0'
+      });
     }
   })
 });


### PR DESCRIPTION
Fix deprecation warnings from Ember 2.1.

For detail see http://emberjs.com/deprecations/v2.x/#toc_ember-debug-function-options