### PR TITLE
always use HTTPS with S3 uploads

### DIFF
--- a/addon/uploaders/s3.js
+++ b/addon/uploaders/s3.js
@@ -48,10 +48,10 @@ export default Uploader.extend({
         url = json.endpoint;
         delete json.endpoint;
       } else if (json.region) {
-        url = `//s3-${json.region}.amazonaws.com/${json.bucket}`;
+        url = `https://s3-${json.region}.amazonaws.com/${json.bucket}`;
         delete json.region;
       } else {
-        url = `//${json.bucket}.s3.amazonaws.com`;
+        url = `https://${json.bucket}.s3.amazonaws.com`;
       }
 
       return this.ajax(url, this.createFormData(file, json));


### PR DESCRIPTION
It's unsafe to do signed uploads to S3 over plain HTTP. Protocol-relative URLs should be also replaced by HTTPS URLs wherever possible. S3 most certainly supports HTTPS, so this should be the default.

Users can still opt out of this by crafting the server response to include an `endpoint` value with plain HTTP or a relative URL, but that should be discouraged.

Let me know if there's anything else to do for this or if you'd like to discuss further :v: