### PR TITLE
use new syntax for ember install in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Ember.js file uploader. Works with any browser that supports
 Ember Uploader is a Ember CLI compatible addon and can be installed as such.
 
 ```
-ember install:addon ember-uploader
+ember install ember-uploader
 ```
 
 #### Basic Setup


### PR DESCRIPTION
```
DEPRECATION: This command has been deprecated. Please use `ember install <addonName>` instead.
```