### PR TITLE
Allow (signing)AjaxSettings to be computed props.

### DIFF
--- a/addon/uploaders/base.js
+++ b/addon/uploaders/base.js
@@ -187,8 +187,10 @@ export default Ember.Object.extend(Ember.Evented, {
    * object
    */
   ajax (url, data = {}, method = this.method) {
+    const ajaxSettings = get(this, 'ajaxSettings');
+
     return this.ajaxPromise({
-      ...this.ajaxSettings,
+      ...ajaxSettings,
       contentType: false,
       processData: false,
       xhr: () => {

--- a/addon/uploaders/s3.js
+++ b/addon/uploaders/s3.js
@@ -69,13 +69,14 @@ export default Uploader.extend({
   sign (file, extra = {}) {
     const url    = get(this, 'signingUrl');
     const method = get(this, 'signingMethod');
+    const signingAjaxSettings = get(this, 'signingAjaxSettings');
 
     extra.name = file.name;
     extra.type = file.type;
     extra.size = file.size;
 
     const settings = {
-      ...this.signingAjaxSettings,
+      ...signingAjaxSettings,
       contentType: 'application/json',
       dataType: 'json',
       data: method.match(/get/i) ? extra : JSON.stringify(extra),

--- a/tests/unit/s3-test.js
+++ b/tests/unit/s3-test.js
@@ -97,3 +97,28 @@ test("it allows overriding ajax sign settings", function () {
 
   equal(Ember.$.ajax.getCall(0).args[0].headers['Content-Type'], 'text/html');
 });
+
+test("it allows signingAjaxSettings to be a computed property", function () {
+  this.stub(Ember.$, 'ajax');
+
+  expect(2);
+
+  const uploader = S3Uploader.extend({
+    _testIterator: 0,
+
+    signingAjaxSettings: Ember.computed('_testIterator', function() {
+      return {
+        headers: {
+          'X-My-Incrementor': this.get('_testIterator'),
+        }
+      };
+    }),
+  }).create();
+
+  uploader.sign('/test');
+  equal(Ember.$.ajax.getCall(0).args[0].headers['X-My-Incrementor'], '0');
+
+  uploader.set('_testIterator', 1);
+  uploader.sign('/test');
+  equal(Ember.$.ajax.getCall(1).args[0].headers['X-My-Incrementor'], '1');
+});

--- a/tests/unit/uploader-test.js
+++ b/tests/unit/uploader-test.js
@@ -196,3 +196,28 @@ test("it allows overriding ajax settings", function() {
 
   equal(Ember.$.ajax.getCall(0).args[0].headers['Content-Type'], 'text/html');
 });
+
+test("it allows ajaxSettings to be a computed property", function() {
+  this.stub(Ember.$, 'ajax');
+
+  expect(2);
+
+  let uploader = Uploader.extend({
+    _testIterator: 0,
+
+    ajaxSettings: Ember.computed('_testIterator', function() {
+      return {
+        headers: {
+          'X-My-Incrementor': this.get('_testIterator'),
+        }
+      };
+    }),
+  }).create();
+
+  uploader.upload(file);
+  equal(Ember.$.ajax.getCall(0).args[0].headers['X-My-Incrementor'], '0');
+
+  uploader.set('_testIterator', 1);
+  uploader.upload(file);
+  equal(Ember.$.ajax.getCall(1).args[0].headers['X-My-Incrementor'], '1');
+});


### PR DESCRIPTION
For cases where an option needs to be computed (think about a time-sensitive token in a header), it would be nice to define a computed property for these values.