### PR TITLE
Allow setting the accept attribute.

### DIFF
--- a/addon/components/file-field.js
+++ b/addon/components/file-field.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 export default Ember.Component.extend(Ember.Evented, {
   tagName: 'input',
   type: 'file',
-  attributeBindings: ['type', 'multiple'],
+  attributeBindings: ['type', 'multiple', 'accept'],
   multiple: false,
   change (event) {
     const input = event.target;


### PR DESCRIPTION
On android in cordova the file field won't work by default unless it's `accept="image/*"`. Just generally limiting the file types is good UX. It's also part of the standard https://www.w3.org/TR/html-markup/input.file.html#input.file.attrs.accept

