### PR TITLE
fix FileList type check in BaseUploader

### DIFF
--- a/addon/uploaders/base.js
+++ b/addon/uploaders/base.js
@@ -88,7 +88,7 @@ export default Ember.Object.extend(Ember.Evented, {
     }
 
     // if is a array of files ...
-    if (isArray(files)) {
+    if (files.constructor === FileList) {
       const paramKey = `${this.toNamespacedParam(this.paramName)}[]`;
 
       for (let i = 0; i < files.length; i++) {


### PR DESCRIPTION
With the release of Ember 2.10 Ember.isArray no longer treats FileList as an array type (https://github.com/emberjs/ember.js/pull/12708).