### PR TITLE
Remove documentation about passing an array to the S3 uploader

### DIFF
--- a/addon/uploaders/s3.js
+++ b/addon/uploaders/s3.js
@@ -33,7 +33,7 @@ export default Uploader.extend({
   /**
    * Request signed upload policy and upload file(s) and any extra data
    *
-   * @param  {object|array} files  One file object or one array of files object
+   * @param  {object} file  A file object
    * @param  {object} extra Extra data to be sent with the upload
    * @return {object} Returns a Ember.RSVP.Promise wrapping the signing
    * request object
@@ -61,7 +61,7 @@ export default Uploader.extend({
   /**
    * Request signed upload policy
    *
-   * @param  {object|array} files  One file object or one array of files object
+   * @param  {object} file  A file object
    * @param  {object} extra Extra data to be sent with the upload
    * @return {object} Returns a Ember.RSVP.Promise wrapping the signing
    * request object


### PR DESCRIPTION
Passing an array of files doesn’t work with the current implementation of the S3 uploader so it should not be documented as such.