### PR TITLE
update ember-cli-babel to ^6.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "uploader"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.6",
+    "ember-cli-babel": "^6.6.0",
     "broccoli-file-creator": "^1.0.1",
     "broccoli-merge-trees": "^1.0.0"
   },


### PR DESCRIPTION
> warning ember-cli-babel@5.2.6: ember-cli-babel 5.x has been deprecated. Please upgrade to at least ember-cli-babel 6.6.0