### PR TITLE
Improve S3 ajax settings docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,10 +137,10 @@ export default FileField.extend({
 ```
 
 ### Modifying the request
-Ember uploader uses jQuery.ajax under the hood so it accepts the same
+Ember Uploader uses jQuery.ajax under the hood so it accepts the same
 ajax settings via the `ajaxSettings` property which is then merged with any
 settings required by Ember Uploader. Here we modify the headers sent with
-the request.
+the request. Note - S3 Uploader uses `signingAjaxSettings` as the relevant key.
 
 ```js
 import Uploader from 'ember-uploader/uploaders/uploader';
@@ -165,14 +165,19 @@ saving secret token on your client.
 
 ```js
 import FileField from 'ember-uploader/components/file-field';
-import Uploader from 'ember-uploader/uploaders/uploader';
+import S3Uploader from 'ember-uploader/uploaders/s3';
 
 export default FileField.extend({
   signingUrl: '',
 
   filesDidChange(files) {
     const uploader = S3Uploader.create({
-      signingUrl: this.get('signingUrl')
+      signingUrl: this.get('signingUrl'),
+      signingAjaxSettings: {
+        headers: {
+          'X-Application-Name': 'Uploader Test'
+        }
+      }
     });
 
     uploader.on('didUpload', response => {


### PR DESCRIPTION
close #182 

In order to preserve composability (S3 extending from base), I think it might best to leave the key `signingAjaxSettings` and just document it better.